### PR TITLE
Add timer decorator

### DIFF
--- a/src/osh/__init__.py
+++ b/src/osh/__init__.py
@@ -1,3 +1,4 @@
 from .logger import Logger
+from .time_machine import time_machine
 
-__all__ = ["Logger"]
+__all__ = ["Logger", "time_machine"]

--- a/src/osh/logger.py
+++ b/src/osh/logger.py
@@ -184,7 +184,7 @@ class Logger:
     """
 
     def __init__(
-        self, name: str, level: int = logging.INFO, thread_id: Optional[str] = None
+        self, name: str, level: int = logging.DEBUG, thread_id: Optional[str] = None
     ):
         """Initialize the Logger.
 

--- a/src/osh/time_machine.py
+++ b/src/osh/time_machine.py
@@ -1,0 +1,54 @@
+import asyncio
+import time
+from functools import wraps
+
+from osh import Logger
+
+logger = Logger("TIME MACHINE")
+
+
+def get_class_name(args):
+    """Helper function to extract the class name if the function is a method of a user-defined class."""
+    if (
+        args
+        and hasattr(args[0], "__class__")
+        and not isinstance(args[0], dict | list | tuple | set)
+    ):
+        return f"{args[0].__class__.__name__}."
+    return ""
+
+
+def time_machine(func):
+    """Decorator to log the time a function takes to execute.
+    Handles both synchronous and asynchronous functions.
+    Logs the class name if the function is a method of a class.
+    """
+
+    @wraps(func)
+    async def async_wrapper(*args, **kwargs):
+        start_time = time.time()
+        result = await func(*args, **kwargs)
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        class_name = get_class_name(args)
+        logger.runtime(
+            f"Function '{class_name}{func.__name__}' executed in {elapsed_time:.4f} seconds."
+        )
+        return result
+
+    @wraps(func)
+    def sync_wrapper(*args, **kwargs):
+        start_time = time.time()
+        result = func(*args, **kwargs)
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        class_name = get_class_name(args)
+        logger.runtime(
+            f"Function '{class_name}{func.__name__}' executed in {elapsed_time:.4f} seconds."
+        )
+        return result
+
+    if asyncio.iscoroutinefunction(func):
+        return async_wrapper
+    else:
+        return sync_wrapper


### PR DESCRIPTION
The debug method uses logging.DEBUG level (which is 10, while INFO is 20). Since DEBUG < INFO, debug messages were being filtered out and not displayed, using logging.DEBUG by default fix the issue
